### PR TITLE
1) Making the value prop required makes it awkward to manually contro…

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@ module.exports = {
         })
     },
     props:{
-        value:{
-            type:String,
-            required:true
-        },
+        value:String,
         lang:true,
         theme:String,
         height:true,
@@ -74,14 +71,15 @@ module.exports = {
         require('brace/ext/emmet');
 
         var editor = vm.editor = ace.edit(this.$el);
+        editor.$blockScrolling = Infinity;
 
         this.$emit('init',editor);
         
-        editor.$blockScrolling = Infinity;
         //editor.setOption("enableEmmet", true);
         editor.getSession().setMode(typeof lang === 'string' ? ( 'ace/mode/' + lang ) : lang);
         editor.setTheme('ace/theme/'+theme);
-        editor.setValue(this.value,1);
+        if(this.value)
+            editor.setValue(this.value,1);
         this.contentBackup = this.value;
 
         editor.on('change',function () {


### PR DESCRIPTION
1) Making the value prop required makes it awkward to manually control the editor
2) If you set the value in the init handler, then you get warnings about $blockScrolling. Moving this line up prevents this
3) Conditionally setting the value allows for finer control in situations where you don't want to use vue's value prop